### PR TITLE
ci: add GitHub Actions deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Biome check
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Build
+        run: pnpm build
+
+  deploy:
+    name: Deploy
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build for Cloudflare
+        run: pnpm build:cloudflare
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for CI/CD to Cloudflare Workers
- **On PR to main**: runs lint (biome), type-check, and build
- **On push to main**: runs all checks + deploys to Cloudflare Workers

## Setup required
Add these secrets in **GitHub repo → Settings → Secrets → Actions**:

| Secret | Value |
|--------|-------|
| `CLOUDFLARE_ACCOUNT_ID` | `fd48a66fcdbd27c259c4a04b78ba62dd` |
| `CLOUDFLARE_API_TOKEN` | Create at [Cloudflare API Tokens](https://dash.cloudflare.com/profile/api-tokens) with **Edit Cloudflare Workers** template |

## Test plan
- [x] Workflow triggers on PR (lint/build check)
- [ ] After adding secrets, verify deploy on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)